### PR TITLE
I added a convenience method...

### DIFF
--- a/src/edu/cmu/cs/lti/ark/tweetnlp/twokenize.scala
+++ b/src/edu/cmu/cs/lti/ark/tweetnlp/twokenize.scala
@@ -288,6 +288,12 @@ object Twokenize {
     tokenizeForTagger(text).toSeq
   }
 
+  // Convenience method to produce a string representation of the 
+  // tokenized tweet in a standard-ish format.
+  def tokenizeToString (text: String): String = {
+  	tokenizeForTagger(text).mkString(" ");
+  }
+
   // Main method
   def main (args: Array[String]) = {
     // force stdin/stdout interpretation as UTF-8


### PR DESCRIPTION
... that simply joins up the tokenizer's output into a whitespace-delimited string, which should make it easier to include this in a larger Tweet-processing pipeline involving Java classes. 

I found myself needing to use Twokenize from a Java class that just needed a string representation of a tokenized Tweet, and was reminded the fact that Java makes this sort of thing way harder than it should be. Luckily, it's almost a one-liner in Scala (+1 for your choice of language, guys!), so I thought it would be a worthwhile addition to the program.
