### PR TITLE
fix stdin on windows

### DIFF
--- a/src/cmu/arktweetnlp/util/BasicFileIO.java
+++ b/src/cmu/arktweetnlp/util/BasicFileIO.java
@@ -43,7 +43,9 @@ public class BasicFileIO {
     public static BufferedReader openFileToReadUTF8(String file) {
         try {
             BufferedReader bReader = null;
-            if (file.endsWith(".gz")) {
+            if (file.equals("/dev/stdin")) {
+                bReader = new BufferedReader(new InputStreamReader(System.in, "UTF-8"));
+            } else if (file.endsWith(".gz")) {
                 bReader = new BufferedReader(new InputStreamReader(
                         new GZIPInputStream(new FileInputStream(file)), "UTF-8"));
             } else {


### PR DESCRIPTION
This fixes stdin so it runs on windows, as windows doesn't have `/dev/stdin`.